### PR TITLE
Add foreign markup to entries.

### DIFF
--- a/src/feedparser_clj/core.clj
+++ b/src/feedparser_clj/core.clj
@@ -26,6 +26,17 @@
 
 (defrecord link [href hreflang length rel title type])
 
+(defrecord foreign-markup [qualified-name text value attributes])
+
+(defn make-foreign-markup
+  [e]
+  (map->foreign-markup {:qualified-name  (.getQualifiedName e)
+                        :text            (when (seq (.getText e))  (.getText e))
+                        :value           (when (seq (.getValue e)) (.getValue e))
+                        :attributes      (when-let [attrs (seq (.getAttributes e))]
+                                           (for [a attrs]
+                                             {:name (.getName a) :value (.getValue a)}))}))
+
 (defn make-enclosure "Create enclosure struct from SyndEnclosure"
   [e]
   (map->enclosure {:length (.getLength e) :type (.getType e)
@@ -77,6 +88,7 @@
                :published-date (.getPublishedDate e)
                :title (text-content (.getTitleEx e))
                :updated-date (.getUpdatedDate e)
+               :foreign-markup (map make-foreign-markup (seq (.getForeignMarkup e)))
                :uri (.getUri e)}))
 
 (defn make-feed "Create a feed struct from a SyndFeed"


### PR DESCRIPTION
Foreign markup was not being carried over when making records, this
retains that information, as best as possible, under the :foreign-markup
key of the entry.

I tried to be as general as possible with the attributes, so that this pull request is hopefully useful to others.  As such it's likely "good enough" but won't solve every case.
